### PR TITLE
Linux based distributions build fix

### DIFF
--- a/BuildLinux.sh
+++ b/BuildLinux.sh
@@ -178,8 +178,8 @@ then
     echo "done"
     echo "Building Orca-Flashforge ..."
     cmake --build build --target Orca-Flashforge
-    echo "Building Orca-Flashforge_profile_validator .."
-    cmake --build build --target Orca-Flashforge_profile_validator
+    echo "Building OrcaSlicer_profile_validator .."
+    cmake --build build --target OrcaSlicer_profile_validator
     ./run_gettext.sh
     echo "done"
 fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,4 +92,4 @@ RUN [[ "$UID" != "0" ]] \
 
 # Using an entrypoint instead of CMD because the binary
 # accepts several command line arguments.
-ENTRYPOINT ["/OrcaSlicer/build/package/bin/orca-slicer"]
+ENTRYPOINT ["/OrcaSlicer/build/package/bin/orca-flashforge"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Orca-Flashforge is an open source slicer for FDM printers.
   - Tools needed: Xcode, Cmake, git, gettext
   - run `build_release_macos.sh`
 
+- Linux (checked on Ubuntu Desktop 22.04 6.8.0-57-generic x86_64)  
+  - Tools needed: [docker](https://docs.docker.com/engine/install/ubuntu/)
+  - run `sh ./DockerBuild.sh`
+  - after successful build run it from docker via `sh DockerRun.sh` or export AppImage from `orcaslicer` container to your local file system
+
 # Note: 
 If you're running Klipper, it's recommended to add the following configuration to your `printer.cfg` file.
 ```

--- a/deps/MPFR/MPFR.cmake
+++ b/deps/MPFR/MPFR.cmake
@@ -25,7 +25,7 @@ else ()
     endif ()
 
     ExternalProject_Add(dep_MPFR
-        URL https://www.mpfr.org/mpfr-current/mpfr-4.2.1.tar.bz2
+        URL https://www.mpfr.org/mpfr-4.2.1/mpfr-4.2.1.tar.bz2
         URL_HASH SHA256=b9df93635b20e4089c29623b19420c4ac848a1b29df1cfd59f26cab0d2666aa0
         DOWNLOAD_DIR ${DEP_DOWNLOAD_DIR}/MPFR
         BUILD_IN_SOURCE ON


### PR DESCRIPTION
Corrected several mistakes (such as dead link and wrong cmake target name) to fix AppImage build process via docker for Linux based distributions.
Modified README with build instructions  for Linux based distributions.